### PR TITLE
Add fileWriter Close retry if file not Complete

### DIFF
--- a/file_writer.go
+++ b/file_writer.go
@@ -211,7 +211,7 @@ func (f *FileWriter) Close() error {
 	}
 
 	// Retry on Complete request returning false
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	backOff := 50 * time.Millisecond
 	for {
@@ -227,7 +227,7 @@ func (f *FileWriter) Close() error {
 			return &os.PathError{"create", f.name, err}
 		}
 		// Return no error if fileWriter is successfully closed.
-		if closed := completeResp.GetResult(); closed {
+		if completeResp.GetResult() {
 			return nil
 		}
 		// If fileWriter is not yet closed, wait for backOff and retry or timeout.

--- a/file_writer.go
+++ b/file_writer.go
@@ -211,7 +211,7 @@ func (f *FileWriter) Close() error {
 	}
 
 	// Retry on Complete request returning false
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	backOff := 50 * time.Millisecond
 	for {
@@ -233,7 +233,9 @@ func (f *FileWriter) Close() error {
 		// If fileWriter is not yet closed, wait for backOff and retry or timeout.
 		select {
 		case <-time.After(backOff):
-			backOff *= 2
+			if backOff < 2*time.Second {
+				backOff *= 2
+			}
 		case <-ctx.Done():
 			return ctx.Err()
 		}


### PR DESCRIPTION
Add backoff & retry to fileWriter Close function if the complete response returns false. The client needs to handle the case where the namenode has not received a finalized status from the datanode.